### PR TITLE
Bugfix: fix misspelling issue - replace outcome with expenses && remove random_state option from test_train_split

### DIFF
--- a/backend/machine_learning/model.py
+++ b/backend/machine_learning/model.py
@@ -89,12 +89,6 @@ def make_prediction(reg, X_test):
     return reg.predict(X_test)
 
 
-def get_MRSE(y_test, pred):
-    score = np.sqrt(mean_squared_error(y_test, pred))
-    # print(f'RMSE Score on Test set: {score:0.2f}')
-    return score
-
-
 def print_stats(y_test, pred):
     print('RMSE: ', round(np.sqrt(mean_squared_error(y_true=y_test, y_pred=pred)), 3))
     print('MAE: ', round(mean_absolute_error(y_true=y_test, y_pred=pred), 3))
@@ -252,7 +246,7 @@ def main():
             main_df = resample_and_create_features(main_df, 'W')
 
         # keep outliers for the income data
-        if forecast_type == 'outcome':
+        if forecast_type == 'expenses':
             # remove outliers dynamically
             z_scores = np.abs(stats.zscore(main_df['amount']))
             threshold = 0.7
@@ -266,7 +260,7 @@ def main():
         X = main_df[resample_features]
         y = main_df[TARGET]
 
-        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
         reg = make_xgboost_reg(X_train, y_train, X_test, y_test, forecast_type)
 

--- a/backend/src/accounts/accounts.service.ts
+++ b/backend/src/accounts/accounts.service.ts
@@ -120,7 +120,7 @@ export class AccountsService {
               },
             },
           },
-          outcome: {
+          expenses: {
             $sum: {
               $cond: {
                 if: { $lt: ['$amount', 0] },
@@ -193,8 +193,8 @@ export class AccountsService {
           income: {
             $round: ['$income', ROUND_VALUE],
           },
-          outcome: {
-            $round: ['$outcome', ROUND_VALUE],
+          expenses: {
+            $round: ['$expenses', ROUND_VALUE],
           },
           byDay: {
             $round: ['$byDay', ROUND_VALUE],
@@ -209,9 +209,9 @@ export class AccountsService {
       },
     ]);
 
-    const { income, outcome, byDay, byWeek, byMonth } = data[0] ?? {
+    const { income, expenses, byDay, byWeek, byMonth } = data[0] ?? {
       income: 0,
-      outcome: 0,
+      expenses: 0,
       byDay: 0,
       byWeek: 0,
       byMonth: 0,
@@ -222,7 +222,7 @@ export class AccountsService {
     const daysInCurrentMonth = moment().daysInMonth();
     return {
       income,
-      outcome,
+      expenses,
       byDay: {
         amount: byDay,
         // difference Btw Budget And Costs

--- a/backend/src/accounts/dto/account-summary-dto.ts
+++ b/backend/src/accounts/dto/account-summary-dto.ts
@@ -1,6 +1,6 @@
 export class AccountSummaryDTO {
   income: number;
-  outcome: number;
+  expenses: number;
   byDay: ByDateRangeDTO;
   byWeek: ByDateRangeDTO;
   byMonth: ByDateRangeDTO;

--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -21,12 +21,12 @@ export class AnalyticsController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Post('forecast/outcome')
-  async forecastOutcome (
+  @Post('forecast/expenses')
+  async forecastExpenses (
     @Body() body: ForecastBodyDTO,
     @Req() req,
   ) {
-    return await this.analyticsService.forecastOutcome(
+    return await this.analyticsService.forecastExpenses(
       req.user.id,
       body.period,
       body.startTime

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -17,7 +17,7 @@ interface MLTransaction {
 }
 
 export const PERIODS = ['1M', '2M', '3M'] as const;
-export const FORECAST_TYPES = ['income', 'outcome'] as const;
+export const FORECAST_TYPES = ['income', 'expenses'] as const;
 
 @Injectable()
 export class AnalyticsService {
@@ -37,7 +37,7 @@ export class AnalyticsService {
     period: '1M',
     nTransactions: 0,
     modelVersion: '1.0',
-    forecastType: 'outcome'
+    forecastType: 'expenses'
   };
 
   validateParams(period: Periods) {
@@ -85,7 +85,7 @@ export class AnalyticsService {
     const options: Forecast['options'] = this.defaultOptions;
 
     let amountFilter: {[key: string]: number} = { $gt: 0 };
-    if (forecastType === 'outcome') amountFilter = { $lt: 0 };
+    if (forecastType === 'expenses') amountFilter = { $lt: 0 };
 
     const transactions = await this.transactionsService.getTransactions(userID, { amount: amountFilter, date: { $lt: startTime} }, { date: 'desc' }, 'date amount -_id');
     options.period = period;
@@ -128,9 +128,9 @@ export class AnalyticsService {
     }).save();
   }
 
-  async forecastOutcome(userID: string, period: Periods, startTime: string) {
+  async forecastExpenses(userID: string, period: Periods, startTime: string) {
     this.validateParams(period);
-    const { transactions, options } = await this.buildParams(userID, period, 'outcome', startTime);
+    const { transactions, options } = await this.buildParams(userID, period, 'expenses', startTime);
 
     const result = await this.forecastModel.find({
       userID: userID,
@@ -144,7 +144,7 @@ export class AnalyticsService {
       return result[0];
     }
     const processedTransactions = this.processTransaction(transactions);
-    const results = await this.forecast(processedTransactions as MLTransaction[], options, 'outcome');
+    const results = await this.forecast(processedTransactions as MLTransaction[], options, 'expenses');
 
     this.logger.log('Creating new forecast instance...');
 

--- a/backend/src/statistics/dto/budget-dto.ts
+++ b/backend/src/statistics/dto/budget-dto.ts
@@ -1,5 +1,5 @@
 export class BudgetDTO {
   name: string;
   budget: number;
-  outcome: number;
+  expenses: number;
 }

--- a/backend/src/statistics/dto/income-expenses-dto.ts
+++ b/backend/src/statistics/dto/income-expenses-dto.ts
@@ -1,0 +1,5 @@
+export class IncomeExpensesDTO {
+  name: string;
+  income: number;
+  expenses: number;
+}

--- a/backend/src/statistics/dto/income-outcome-dto.ts
+++ b/backend/src/statistics/dto/income-outcome-dto.ts
@@ -1,5 +1,0 @@
-export class IncomeOutcomeDTO {
-  name: string;
-  income: number;
-  outcome: number;
-}

--- a/backend/src/statistics/statistics.controller.ts
+++ b/backend/src/statistics/statistics.controller.ts
@@ -14,18 +14,18 @@ export class StatisticsController {
   constructor(private readonly statisticsService: StatisticsService) {}
 
   @UseGuards(JwtAuthGuard)
-  @Get('/income_outcome/:date_type/:date_detail?')
-  async getIncomeOutcomeStatisticsData(
+  @Get('/income_expenses/:date_type/:date_detail?')
+  async getIncomeExpensesStatisticsData(
     @Req() req,
     @Param('date_type') dateType: string,
     @Param('date_detail') dateDetail?: string,
   ) {
     if (dateType === 'in_one_year') {
-      return await this.statisticsService.getIncomeOutcomeStatisticsDataForYear(
+      return await this.statisticsService.getIncomeExpensesStatisticsDataForYear(
         req.user.id,
       );
     } else if (dateType === 'in_one_month' && dateDetail) {
-      return await this.statisticsService.getIncomeOutcomeStatisticsDataForMonth(
+      return await this.statisticsService.getIncomeExpensesStatisticsDataForMonth(
         req.user.id,
         dateDetail,
       );

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -1,7 +1,7 @@
 import { ROUND_VALUE } from '@utils/constants';
 import { TopShopDTO } from './dto/top-shops-dto';
 import { TopCategoriesDTO } from './dto/top-categories-dto';
-import { IncomeOutcomeDTO } from './dto/income-outcome-dto';
+import { IncomeExpensesDTO } from './dto/income-expenses-dto';
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
@@ -51,7 +51,8 @@ export class StatisticsService {
       },
     };
   }
-  get outcomeSum() {
+
+  get expensesSum() {
     return {
       $sum: {
         $cond: {
@@ -63,10 +64,10 @@ export class StatisticsService {
     };
   }
 
-  async getIncomeOutcomeStatisticsDataForYear(
+  async getIncomeExpensesStatisticsDataForYear(
     userID: string,
-  ): Promise<IncomeOutcomeDTO[]> {
-    const data: IncomeOutcomeDTO[] = await this.transactionModel.aggregate([
+  ): Promise<IncomeExpensesDTO[]> {
+    const data: IncomeExpensesDTO[] = await this.transactionModel.aggregate([
       {
         $match: {
           $expr: {
@@ -78,7 +79,7 @@ export class StatisticsService {
         $group: {
           _id: { $dateToString: { format: '%Y-%m', date: '$date' } },
           income: this.incomeSum,
-          outcome: this.outcomeSum,
+          expenses: this.expensesSum,
         },
       },
       {
@@ -88,8 +89,8 @@ export class StatisticsService {
           income: {
             $round: ['$income', ROUND_VALUE],
           },
-          outcome: {
-            $round: [{ $abs: '$outcome' }, ROUND_VALUE],
+          expenses: {
+            $round: [{ $abs: '$expenses' }, ROUND_VALUE],
           },
         },
       },
@@ -101,7 +102,7 @@ export class StatisticsService {
           acc.push({
             name: date,
             income: 0,
-            outcome: 0,
+            expenses: 0,
           });
         }
 
@@ -110,11 +111,11 @@ export class StatisticsService {
       .sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  async getIncomeOutcomeStatisticsDataForMonth(
+  async getIncomeExpensesStatisticsDataForMonth(
     userID: string,
     numberOfMonth: string,
-  ): Promise<IncomeOutcomeDTO[]> {
-    const data: IncomeOutcomeDTO[] = await this.transactionModel.aggregate([
+  ): Promise<IncomeExpensesDTO[]> {
+    const data: IncomeExpensesDTO[] = await this.transactionModel.aggregate([
       {
         $match: {
           $expr: {
@@ -134,7 +135,7 @@ export class StatisticsService {
         $group: {
           _id: { $dateToString: { format: '%Y-%m-%d', date: '$date' } },
           income: this.incomeSum,
-          outcome: this.outcomeSum,
+          expenses: this.expensesSum,
         },
       },
       {
@@ -144,8 +145,8 @@ export class StatisticsService {
           income: {
             $round: ['$income', ROUND_VALUE],
           },
-          outcome: {
-            $round: [{ $abs: '$outcome' }, ROUND_VALUE],
+          expenses: {
+            $round: [{ $abs: '$expenses' }, ROUND_VALUE],
           },
         },
       },
@@ -156,7 +157,7 @@ export class StatisticsService {
           acc.push({
             name: date,
             income: 0,
-            outcome: 0,
+            expenses: 0,
           });
         }
 
@@ -198,7 +199,7 @@ export class StatisticsService {
       {
         $group: {
           _id: { $dateToString: { format: '%Y-%m-%d', date: '$date' } },
-          amount: type === 'income' ? this.incomeSum : this.outcomeSum
+          amount: type === 'income' ? this.incomeSum : this.expensesSum
         },
       },
       {
@@ -231,15 +232,15 @@ export class StatisticsService {
       {
         $group: {
           _id: { $dateToString: { format: '%Y-%m', date: '$date' } },
-          outcome: this.outcomeSum,
+          expenses: this.expensesSum,
         },
       },
       {
         $project: {
           _id: 0,
           name: '$_id',
-          outcome: {
-            $round: [{ $abs: '$outcome' }, ROUND_VALUE],
+          expenses: {
+            $round: [{ $abs: '$expenses' }, ROUND_VALUE],
           },
         },
       },
@@ -251,7 +252,7 @@ export class StatisticsService {
           acc.push({
             name: date,
             budget: 0,
-            outcome: 0,
+            expenses: 0,
           });
         }
 
@@ -297,15 +298,15 @@ export class StatisticsService {
       {
         $group: {
           _id: { $dateToString: { format: '%Y-%m-%d', date: '$date' } },
-          outcome: this.outcomeSum,
+          expenses: this.expensesSum,
         },
       },
       {
         $project: {
           _id: 0,
           name: '$_id',
-          outcome: {
-            $round: [{ $abs: '$outcome' }, ROUND_VALUE],
+          expenses: {
+            $round: [{ $abs: '$expenses' }, ROUND_VALUE],
           },
         },
       },
@@ -316,7 +317,7 @@ export class StatisticsService {
           acc.push({
             name: date,
             budget: 0,
-            outcome: 0,
+            expenses: 0,
           });
         }
 

--- a/backend/test/statistics.e2e-spec.ts
+++ b/backend/test/statistics.e2e-spec.ts
@@ -1,8 +1,8 @@
 describe('StatisticsController (e2e)', () => {
-  it('/income_outcome/:date_type/:date_detail (GET) - get income-outcome aggregated data', () => {
+  it('/income_expenses/:date_type/:date_detail (GET) - get income-expenses aggregated data', () => {
     return Promise.resolve(true);
   });
-  it('/budget/:date_type/:date_detail (GET) - get budget-outcome aggregated data', () => {
+  it('/budget/:date_type/:date_detail (GET) - get budget-expenses aggregated data', () => {
     return Promise.resolve(true);
   });
   it('/top_categories (GET) - get top categories aggregated data', () => {

--- a/frontend/src/components/AnalyticsView/AnalyticsView.tsx
+++ b/frontend/src/components/AnalyticsView/AnalyticsView.tsx
@@ -104,7 +104,7 @@ function AnalyticsView() {
   const handleOpenForecastModal = () => {
     modalRef.current?.open({
       options: {
-        title: 'Forecast income or outcome',
+        title: 'Forecast income or expenses',
       },
       renderer: (
         <ForecastForm

--- a/frontend/src/components/AnalyticsView/ForecastForm/ForecastFormConfigurations.ts
+++ b/frontend/src/components/AnalyticsView/ForecastForm/ForecastFormConfigurations.ts
@@ -3,13 +3,12 @@ import * as Yup from 'yup';
 import { ForecastFormData } from './ForecastForm.types';
 
 export const SUPPORTED_FORECAST_PERIODS = ['1M', '2M', '3M'] as const;
-
 const ForecastOptionsShape = {
   period: Yup.mixed()
     .oneOf(SUPPORTED_FORECAST_PERIODS as unknown as any[])
     .required('Required'),
   forecastType: Yup.mixed()
-    .oneOf(['income', 'outcome'])
+    .oneOf(['income', 'expenses'])
     .required('Required')
 };
 
@@ -42,7 +41,7 @@ export const controls: ControlProps[] = [
     controlType: 'select',
     name: 'forecastType',
     label: 'Forecast type',
-    value: 'outcome',
+    value: 'expenses',
     description: `Choose forecast type`,
     required: true,
     options: [
@@ -51,8 +50,8 @@ export const controls: ControlProps[] = [
         label: 'Income',
       },
       {
-        value: 'outcome',
-        label: 'Outcome',
+        value: 'expenses',
+        label: 'Expenses',
       },
     ],
   },
@@ -66,6 +65,6 @@ export const controls: ControlProps[] = [
 
 export const defaultData: ForecastFormData = {
   period: '1M',
-  forecastType: 'outcome',
+  forecastType: 'expenses',
   startTime: ''
 };

--- a/frontend/src/components/StatisticsView/Charts/BudgetBarChart.tsx
+++ b/frontend/src/components/StatisticsView/Charts/BudgetBarChart.tsx
@@ -17,14 +17,14 @@ import './Charts.scss';
 import { IChartProps } from './Charts.types';
 
 const renderBarShape =
-  (id: 'budget' | 'outcome') =>
+  (id: 'budget' | 'expenses') =>
   ({ height, width, x, y, fillOpacity }: any) => {
     const colors = {
       budget: {
         from: '#e79c44',
         to: '#d75528',
       },
-      outcome: {
+      expenses: {
         from: '#e9354f',
         to: '#a23363',
       },
@@ -123,11 +123,11 @@ const BudgetBarChart = (props: IChartProps<BudgetStatisticsData>) => {
             shape={renderBarShape('budget')}
           />
           <Bar
-            dataKey="outcome"
+            dataKey="expenses"
             fill="#a23363"
             minPointSize={10}
-            fillOpacity={focusBar === 'outcome' || !focusBar ? 1 : 0.3}
-            shape={renderBarShape('outcome')}
+            fillOpacity={focusBar === 'expenses' || !focusBar ? 1 : 0.3}
+            shape={renderBarShape('expenses')}
           />
         </BarChart>
       </ResponsiveContainer>

--- a/frontend/src/components/StatisticsView/Charts/IncomeExpensesBarChart.tsx
+++ b/frontend/src/components/StatisticsView/Charts/IncomeExpensesBarChart.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-import { IncomeOutcomeStatisticsData } from '@shared/interfaces';
+import { IncomeExpensesStatisticsData } from '@shared/interfaces';
 import { dateFormatter } from '@shared/utils';
 import { useState } from 'react';
 import {
@@ -17,14 +17,14 @@ import './Charts.scss';
 import { IChartProps } from './Charts.types';
 
 const renderBarShape =
-  (id: 'income' | 'outcome') =>
+  (id: 'income' | 'expenses') =>
   ({ height, width, x, y, fillOpacity }: any) => {
     const colors = {
       income: {
         from: '#00ddfa',
         to: '#4d33cc',
       },
-      outcome: {
+      expenses: {
         from: '#e9354f',
         to: '#a23363',
       },
@@ -84,8 +84,8 @@ const CustomTooltip = (props: any) => {
   return null;
 };
 
-const IncomeOutcomeBarChart = (
-  props: IChartProps<IncomeOutcomeStatisticsData>,
+const IncomeExpensesBarChart = (
+  props: IChartProps<IncomeExpensesStatisticsData>,
 ) => {
   const { chartData } = props;
   const [focusBar, setFocusBar] = useState('');
@@ -98,7 +98,7 @@ const IncomeOutcomeBarChart = (
   };
 
   return (
-    <div className="IncomeOutcomeBarChart">
+    <div className="IncomeExpensesBarChart">
       <ResponsiveContainer width="100%" height={300}>
         <BarChart data={chartData}>
           <CartesianGrid vertical={false} stroke="#737687" />
@@ -126,11 +126,11 @@ const IncomeOutcomeBarChart = (
             shape={renderBarShape('income')}
           />
           <Bar
-            dataKey="outcome"
+            dataKey="expenses"
             minPointSize={5}
             fill="#a23363"
-            fillOpacity={focusBar === 'outcome' || !focusBar ? 1 : 0.3}
-            shape={renderBarShape('outcome')}
+            fillOpacity={focusBar === 'expenses' || !focusBar ? 1 : 0.3}
+            shape={renderBarShape('expenses')}
           />
         </BarChart>
       </ResponsiveContainer>
@@ -138,4 +138,4 @@ const IncomeOutcomeBarChart = (
   );
 };
 
-export default IncomeOutcomeBarChart;
+export default IncomeExpensesBarChart;

--- a/frontend/src/components/StatisticsView/Charts/IncomeExpensesLineChart.tsx
+++ b/frontend/src/components/StatisticsView/Charts/IncomeExpensesLineChart.tsx
@@ -1,4 +1,4 @@
-import { IncomeOutcomeStatisticsData } from '@shared/interfaces';
+import { IncomeExpensesStatisticsData } from '@shared/interfaces';
 import { dateFormatter } from '@shared/utils';
 import {
   LineChart,
@@ -34,8 +34,8 @@ const CustomTooltip = (props: any) => {
   return null;
 };
 
-const IncomeOutcomeLineChart = (
-  props: IChartProps<IncomeOutcomeStatisticsData>,
+const IncomeExpensesLineChart = (
+  props: IChartProps<IncomeExpensesStatisticsData>,
 ) => {
   const { chartData } = props;
   return (
@@ -55,7 +55,7 @@ const IncomeOutcomeLineChart = (
         />
         <Line
           type="monotone"
-          dataKey="outcome"
+          dataKey="expenses"
           stroke="#a23363"
           strokeWidth={3}
           activeDot={{ r: 8 }}
@@ -65,4 +65,4 @@ const IncomeOutcomeLineChart = (
   );
 };
 
-export default IncomeOutcomeLineChart;
+export default IncomeExpensesLineChart;

--- a/frontend/src/components/StatisticsView/IncomeExpenses/IncomeExpenses.scss
+++ b/frontend/src/components/StatisticsView/IncomeExpenses/IncomeExpenses.scss
@@ -1,6 +1,6 @@
 @import '@styles/shared.scss';
 
-.IncomeOutcomeContainer {
+.IncomeExpensesContainer {
   margin-top: 30px;
   .TopSection {
     display: flex;

--- a/frontend/src/components/StatisticsView/IncomeExpenses/IncomeExpenses.tsx
+++ b/frontend/src/components/StatisticsView/IncomeExpenses/IncomeExpenses.tsx
@@ -1,13 +1,13 @@
 import Switcher from '@base/Switcher';
 import { useStatisticsRepository } from '@repos';
-import { IncomeOutcomeStatisticsData } from '@shared/interfaces';
+import { IncomeExpensesStatisticsData } from '@shared/interfaces';
 import { useEffect, useState } from 'react';
-import IncomeOutcomeBarChart from '../Charts/IncomeOutcomeBarChart';
-import IncomeOutcomeLineChart from '../Charts/IncomeOutcomeLineChart';
+import IncomeExpensesBarChart from '../Charts/IncomeExpensesBarChart';
+import IncomeExpensesLineChart from '../Charts/IncomeExpensesLineChart';
 import StatisticsDataController, {
   StatisticsDataControllerConfig,
 } from '../StatisticsDataController/StatisticsDataController';
-import './IncomeOutcome.scss';
+import './IncomeExpenses.scss';
 
 const VIEW_MODE_OPTIONS = [
   {
@@ -20,9 +20,9 @@ const VIEW_MODE_OPTIONS = [
   },
 ];
 
-function IncomeOutcome() {
-  const [chartData, setChartData] = useState<IncomeOutcomeStatisticsData[]>();
-  const { getIncomeOutcomeStatisticsData } = useStatisticsRepository();
+function IncomeExpenses() {
+  const [chartData, setChartData] = useState<IncomeExpensesStatisticsData[]>();
+  const { getIncomeExpensesStatisticsData } = useStatisticsRepository();
   const [dataConfig, setDataConfig] =
     useState<StatisticsDataControllerConfig>();
 
@@ -31,7 +31,7 @@ function IncomeOutcome() {
   useEffect(() => {
     const params = dataConfig ? Object.values(dataConfig) : [];
     params.length &&
-      getIncomeOutcomeStatisticsData(params).then(
+      getIncomeExpensesStatisticsData(params).then(
         (data) => data && setChartData(data),
       );
   }, [dataConfig]);
@@ -48,16 +48,16 @@ function IncomeOutcome() {
 
   const renderChart = () => {
     if (viewMode === 'barChart' && chartData)
-      return <IncomeOutcomeBarChart chartData={chartData} />;
+      return <IncomeExpensesBarChart chartData={chartData} />;
     if (viewMode === 'lineChart' && chartData)
-      return <IncomeOutcomeLineChart chartData={chartData} />;
+      return <IncomeExpensesLineChart chartData={chartData} />;
   };
 
   return (
-    <div className="IncomeOutcomeContainer">
+    <div className="IncomeExpensesContainer">
       <div className="TopSection">
         <div className="LeftSide">
-          <span className="TopSectionTitle">Income & Outcome</span>
+          <span className="TopSectionTitle">Income & Expenses</span>
           <Switcher
             value={viewMode}
             options={VIEW_MODE_OPTIONS}
@@ -71,4 +71,4 @@ function IncomeOutcome() {
   );
 }
 
-export default IncomeOutcome;
+export default IncomeExpenses;

--- a/frontend/src/components/StatisticsView/StatisticsView.tsx
+++ b/frontend/src/components/StatisticsView/StatisticsView.tsx
@@ -3,7 +3,7 @@ import { useStore } from '@store';
 import { useObservableState } from 'observable-hooks';
 import Budget from './Budget/Budget';
 import Category from './Category/Category';
-import IncomeOutcome from './IncomeOutcome/IncomeOutcome';
+import IncomeExpenses from './IncomeExpenses/IncomeExpenses';
 import Shop from './Shop/Shop';
 import './StatisticsView.scss';
 
@@ -15,7 +15,7 @@ function StatisticsView() {
       {loading && <Loader />}
       <div className="ViewTitle">Statistics</div>
       <div className="StatisticsChartsContainer">
-        <IncomeOutcome />
+        <IncomeExpenses />
         <Budget />
         <div className="PieCharts">
           <Category />

--- a/frontend/src/components/SummaryView/SummaryView.scss
+++ b/frontend/src/components/SummaryView/SummaryView.scss
@@ -61,7 +61,7 @@
           color: rgba($color: $successColor, $alpha: 0.3);
           outline: 2px solid rgba($color: $successColor, $alpha: 0.3);
         }
-        &.outcome {
+        &.expenses {
           color: rgba($color: $errorColor, $alpha: 0.3);
           outline: 2px solid rgba($color: $errorColor, $alpha: 0.3);
         }

--- a/frontend/src/components/SummaryView/SummaryView.tsx
+++ b/frontend/src/components/SummaryView/SummaryView.tsx
@@ -41,7 +41,7 @@ function SummaryView() {
       <div key={`${name}_${index}`} className="TransactionItemBlock">
         <div
           className={classMap(
-            { income: isIncome, outcome: !isIncome },
+            { income: isIncome, expenses: !isIncome },
             'TypeOfTransaction',
           )}
         >

--- a/frontend/src/components/TransactionsView/TransactionForm/TransactionForm.tsx
+++ b/frontend/src/components/TransactionsView/TransactionForm/TransactionForm.tsx
@@ -35,7 +35,7 @@ const TransactionForm = forwardRef(function TransactionForm(
       const editFormControls = controls.reduce((acc, control) => {
         if (editFields.includes(control.name)) acc.push(control);
         if (control.name === 'transactionType' && control.controlType === 'switcher') {
-          control.value = clonedData.amount < 0 ? 'outcome' : 'income';
+          control.value = clonedData.amount < 0 ? 'expenses' : 'income';
           clonedData.amount = Math.abs(clonedData.amount);
         }
         if (control.name === 'category' && control.controlType === 'tagEditor') {

--- a/frontend/src/components/TransactionsView/TransactionForm/TransactionForm.types.ts
+++ b/frontend/src/components/TransactionsView/TransactionForm/TransactionForm.types.ts
@@ -9,7 +9,7 @@ export type TransactionFormData =
   | EditTransactionRequest;
 
 export type TransactionRawFormData<T> = T & {
-  transactionType: 'income' | 'outcome';
+  transactionType: 'income' | 'expenses';
 }
 
 export interface ITransactionFormProps {

--- a/frontend/src/components/TransactionsView/TransactionForm/TransactionFormConfigurations.ts
+++ b/frontend/src/components/TransactionsView/TransactionForm/TransactionFormConfigurations.ts
@@ -53,7 +53,7 @@ export const controls: ControlProps[] = [
     value: 'income',
     options: [
       { value: 'income', label: 'Income' },
-      { value: 'outcome', label: 'Outcome' }
+      { value: 'expenses', label: 'Expenses' }
     ]
   },
   {

--- a/frontend/src/components/TransactionsView/TransactionsView.scss
+++ b/frontend/src/components/TransactionsView/TransactionsView.scss
@@ -165,7 +165,7 @@
           &.income {
             outline: 2px solid rgba($color: $successColor, $alpha: 0.3);
           }
-          &.outcome {
+          &.expenses {
             outline: 2px solid rgba($color: $errorColor, $alpha: 0.3);
           }
         }

--- a/frontend/src/components/TransactionsView/TransactionsView.tsx
+++ b/frontend/src/components/TransactionsView/TransactionsView.tsx
@@ -199,7 +199,7 @@ function TransactionsView() {
     transactionId: string,
   ) => {
     const { transactionType, ...data } = values;
-    if (transactionType === 'outcome') data.amount = -data.amount;
+    if (transactionType === 'expenses') data.amount = -data.amount;
 
     editTransaction(data, transactionId).then(() => {
       if (!transactionErrors) modalRef.current?.close();
@@ -367,7 +367,7 @@ function TransactionsView() {
         <div className="Block">
           <div
             className={classMap(
-              { income: amount > 0, outcome: amount < 0 },
+              { income: amount > 0, expenses: amount < 0 },
               'TransactionCategory Block',
             )}
           >

--- a/frontend/src/components/UserMenu/UserMenu.scss
+++ b/frontend/src/components/UserMenu/UserMenu.scss
@@ -210,7 +210,7 @@
         transform: rotate(-40deg);
       }
 
-      &.Outcome .IconContainer {
+      &.Expenses .IconContainer {
         transform: rotate(135deg);
       }
     }

--- a/frontend/src/components/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/UserMenu/UserMenu.tsx
@@ -45,8 +45,8 @@ function UserMenu() {
       currency: 'UAH',
     },
     {
-      ref: 'outcome',
-      name: 'Outcome',
+      ref: 'expenses',
+      name: 'Expenses',
       amount: 0,
       currency: 'UAH',
     },
@@ -55,7 +55,7 @@ function UserMenu() {
   const dateSummaryConfigDefault: IDateSummaryWidgetConfig[] = [
     {
       ref: 'byDay',
-      name: 'Daily Outcome',
+      name: 'Daily Expense',
       amount: 0,
       percentage: '0%',
       currency: 'UAH',
@@ -63,7 +63,7 @@ function UserMenu() {
     },
     {
       ref: 'byWeek',
-      name: 'Weekly Outcome',
+      name: 'Weekly Expenses',
       amount: 0,
       percentage: '0%',
       currency: 'UAH',
@@ -71,7 +71,7 @@ function UserMenu() {
     },
     {
       ref: 'byMonth',
-      name: 'Monthly Outcome',
+      name: 'Monthly Expenses',
       amount: 0,
       percentage: '0%',
       currency: 'UAH',
@@ -176,7 +176,7 @@ function UserMenu() {
 
   const handleCreateTransaction = (values: TransactionRawFormData<CreateTransactionRequest>) => {
     const { transactionType, ...data } = values;
-    if (transactionType === 'outcome') data.amount = -data.amount;
+    if (transactionType === 'expenses') data.amount = -data.amount;
 
     createTransaction(data).then(() => {
       if (!transactionErrors) modalRef.current?.close();

--- a/frontend/src/components/UserMenu/UserMenu.types.ts
+++ b/frontend/src/components/UserMenu/UserMenu.types.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IUserMenuProps {}
 export interface ISummaryWidgetConfig {
-  ref: 'income' | 'outcome';
+  ref: 'income' | 'expenses';
   name: string;
   amount: number;
   currency: string;

--- a/frontend/src/helpers/api/statisticsApi.ts
+++ b/frontend/src/helpers/api/statisticsApi.ts
@@ -1,9 +1,9 @@
 import { axiosAuthInstance } from './index';
 
 export const useStatisticsApi = () => {
-  const getIncomeOutcomeStatisticsData = (params?: string[]) => {
+  const getIncomeExpensesStatisticsData = (params?: string[]) => {
     return axiosAuthInstance.get(
-      `/statistics/income_outcome/${params?.join('/') ?? ''}`,
+      `/statistics/income_expenses/${params?.join('/') ?? ''}`,
     );
   };
 
@@ -22,7 +22,7 @@ export const useStatisticsApi = () => {
   };
 
   return {
-    getIncomeOutcomeStatisticsData,
+    getIncomeExpensesStatisticsData,
     getBudgetStatisticsData,
     getTopCategoriesStatisticsData,
     getTopShopsStatisticsData,

--- a/frontend/src/helpers/repositories/useStatisticsRepo.ts
+++ b/frontend/src/helpers/repositories/useStatisticsRepo.ts
@@ -2,7 +2,7 @@ import {
   TopCategoriesStatisticsData,
   TopShopsStatisticsData,
   BudgetStatisticsData,
-  IncomeOutcomeStatisticsData,
+  IncomeExpensesStatisticsData,
 } from '@interfaces';
 import { setErrorToState, repoWrapper } from './utils';
 import { useStatisticsObservable } from '@observables';
@@ -13,11 +13,11 @@ export const useStatisticsRepository = () => {
   const statisticsApi = useStatisticsApi();
   const statisticsObservable = useStatisticsObservable();
 
-  const getIncomeOutcomeStatisticsData = (parameters?: string[]) => {
+  const getIncomeExpensesStatisticsData = (parameters?: string[]) => {
     return repoWrapper(statisticsObservable, () =>
       statisticsApi
-        .getIncomeOutcomeStatisticsData(parameters)
-        .then(({ data }: AxiosResponse<IncomeOutcomeStatisticsData[]>) => data)
+        .getIncomeExpensesStatisticsData(parameters)
+        .then(({ data }: AxiosResponse<IncomeExpensesStatisticsData[]>) => data)
         .catch((err) => setErrorToState(err, statisticsObservable)),
     );
   };
@@ -52,7 +52,7 @@ export const useStatisticsRepository = () => {
   const getStatisticsObservable = () => statisticsObservable.getObservable();
 
   return {
-    getIncomeOutcomeStatisticsData,
+    getIncomeExpensesStatisticsData,
     getBudgetStatisticsData,
     getTopCategoriesStatisticsData,
     getTopShopsStatisticsData,

--- a/frontend/src/shared/interfaces/Accounts.ts
+++ b/frontend/src/shared/interfaces/Accounts.ts
@@ -18,7 +18,7 @@ export type EditAccountRequest = Pick<IAccount, 'name' | 'description'>;
 
 export type AccountSummaryData = {
   income: number;
-  outcome: number;
+  expenses: number;
   byDay: ByDateRangeSummary;
   byWeek: ByDateRangeSummary;
   byMonth: ByDateRangeSummary;

--- a/frontend/src/shared/interfaces/Analytics.ts
+++ b/frontend/src/shared/interfaces/Analytics.ts
@@ -2,7 +2,7 @@
 import { SUPPORTED_FORECAST_PERIODS } from "@components/AnalyticsView/ForecastForm/ForecastFormConfigurations";
 
 export type ForecastPeriods = typeof SUPPORTED_FORECAST_PERIODS[number];
-export type ForecastType = 'income' | 'outcome';
+export type ForecastType = 'income' | 'expenses';
 export type ForecastOptions = {
   period: ForecastPeriods,
   forecastType: ForecastType,

--- a/frontend/src/shared/interfaces/Statistics.ts
+++ b/frontend/src/shared/interfaces/Statistics.ts
@@ -1,13 +1,13 @@
-export type IncomeOutcomeStatisticsData = {
+export type IncomeExpensesStatisticsData = {
   name: string;
   income: number;
-  outcome: number;
+  expenses: number;
 };
 
 export type BudgetStatisticsData = {
   name: string;
   budget: number;
-  outcome: number;
+  expenses: number;
 };
 
 export type TopCategoriesStatisticsData = {


### PR DESCRIPTION
-  Replace "outcome" references with "expenses"
-  Remove random_state option from test_train_split method to avoid data inconsistencies which is really bad for time series forcasting